### PR TITLE
Context again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ lint: ## Run gofmt and goimports in lint mode
 	${DOCKER_CMD} golint -set_exit_status ./metrics/...
 	${DOCKER_CMD} golint -set_exit_status ./nettest/...
 	${DOCKER_CMD} golint -set_exit_status ./
+	${DOCKER_CMD} go tool vet ./handlers
+	${DOCKER_CMD} go tool vet ./log
+	${DOCKER_CMD} go tool vet ./metrics
+	${DOCKER_CMD} go tool vet ./nettest
 
 format: ## Run gofmt to format the code
 	${DOCKER_CMD} gofmt -s -w ${CODE}

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ clean: ## Clean docker and git info
 	docker-compose rm -f
 	docker-compose down || echo "Cleaned"
 	git clean -d -f -f
+	rm -rf .glide
 
 # Build targets
 .SILENT: help

--- a/handlers/context_test.go
+++ b/handlers/context_test.go
@@ -93,7 +93,7 @@ func TestContextUpdatesTheRequestContext(t *testing.T) {
 				ProtoMinor: 0,
 				URL:        &url.URL{Host: "www.example.com:443"},
 				Host:       "www.example.com:443",
-				RemoteAddr: "192.168.100.5",
+				RemoteAddr: "192.168.100.5:9843",
 			},
 			map[string]interface{}{
 				"http.method":     "CONNECT",
@@ -101,7 +101,7 @@ func TestContextUpdatesTheRequestContext(t *testing.T) {
 				"http.uri":        "www.example.com:443",
 				"http.path":       "www.example.com:443",
 				"http.host":       "www.example.com:443",
-				"http.user":       "",
+				"http.user":       "192.168.100.5",
 				"http.ref":        "",
 				"http.user-agent": "",
 			},

--- a/handlers/request_logger.go
+++ b/handlers/request_logger.go
@@ -175,6 +175,7 @@ func uriPath(req *http.Request, url url.URL) (uri string) {
 func getUserIP(req *http.Request) (net.IP, error) {
 	for _, h := range []string{"X-Forwarded-For", "X-Real-Ip"} {
 		for _, ip := range strings.Split(req.Header.Get(h), ",") {
+			log.With(log.KV{"ip": ip, "header": h}).Debug("looking up from header")
 			// header can contain spaces too, strip those out.
 			userIP := net.ParseIP(strings.Replace(ip, " ", "", -1))
 			if userIP == nil {
@@ -184,6 +185,7 @@ func getUserIP(req *http.Request) (net.IP, error) {
 		}
 	}
 	ip, _, err := net.SplitHostPort(req.RemoteAddr)
+	log.With(log.KV{"ip": ip}).Debug("looking up ip from remote Addr")
 	if err != nil {
 		return nil, fmt.Errorf("getUserIP: %q is not a valid IP:Port", req.RemoteAddr)
 	}

--- a/handlers/request_logger.go
+++ b/handlers/request_logger.go
@@ -174,18 +174,18 @@ func uriPath(req *http.Request, url url.URL) (uri string) {
 // then the `req.RemoteAddr`
 func getUserIP(req *http.Request) (net.IP, error) {
 	for _, h := range []string{"X-Forwarded-For", "X-Real-Ip"} {
-		for _, ip := range strings.Split(req.Header.Get(h), ",") {
-			log.With(log.KV{"ip": ip, "header": h}).Debug("looking up from header")
-			// header can contain spaces too, strip those out.
-			userIP := net.ParseIP(strings.Replace(ip, " ", "", -1))
-			if userIP == nil {
-				return nil, fmt.Errorf("getUserIP: %q is not a valid IP", ip)
+		if req.Header.Get(h) != "" {
+			for _, ip := range strings.Split(req.Header.Get(h), ",") {
+				// header can contain spaces too, strip those out.
+				userIP := net.ParseIP(strings.Replace(ip, " ", "", -1))
+				if userIP == nil {
+					return nil, fmt.Errorf("getUserIP: %q is not a valid IP", ip)
+				}
+				return userIP, nil
 			}
-			return userIP, nil
 		}
 	}
 	ip, _, err := net.SplitHostPort(req.RemoteAddr)
-	log.With(log.KV{"ip": ip}).Debug("looking up ip from remote Addr")
 	if err != nil {
 		return nil, fmt.Errorf("getUserIP: %q is not a valid IP:Port", req.RemoteAddr)
 	}

--- a/handlers/request_logger_test.go
+++ b/handlers/request_logger_test.go
@@ -26,7 +26,7 @@ func TestParseUri(t *testing.T) {
 				ProtoMinor: 0,
 				URL:        &url.URL{Host: "www.example.com:443"},
 				Host:       "www.example.com:443",
-				RemoteAddr: "192.168.100.5",
+				RemoteAddr: "192.168.100.5:9843",
 			},
 			"www.example.com:443",
 		},
@@ -63,7 +63,7 @@ func TestUriPath(t *testing.T) {
 				ProtoMinor: 0,
 				URL:        &url.URL{Host: "www.example.com:443"},
 				Host:       "www.example.com:443",
-				RemoteAddr: "192.168.100.5",
+				RemoteAddr: "192.168.100.5:9843",
 			},
 			"www.example.com:443",
 		},
@@ -84,6 +84,13 @@ func TestUriPath(t *testing.T) {
 }
 
 func TestGetUserIP(t *testing.T) {
+
+	singleHeader := newRequest("GET", "http://example.com")
+	singleHeader.Header.Add("X-Forwarded-For", "192.168.100.5")
+
+	multipleHeader := newRequest("GET", "http://example.com")
+	multipleHeader.Header.Add("X-Forwarded-For", "192.168.100.5, 192.168.100.12")
+
 	cases := map[string]struct {
 		req      *http.Request
 		expected interface{}
@@ -91,6 +98,26 @@ func TestGetUserIP(t *testing.T) {
 		"undefined": {
 			newRequest("GET", "http://example.com"),
 			(net.IP)(nil),
+		},
+		"remote Addr": {
+			&http.Request{
+				Method:     "CONNECT",
+				Proto:      "HTTP/2.0",
+				ProtoMajor: 2,
+				ProtoMinor: 0,
+				URL:        &url.URL{Host: "www.example.com:443"},
+				Host:       "www.example.com:443",
+				RemoteAddr: "192.168.100.5:4382",
+			},
+			net.ParseIP("192.168.100.5"),
+		},
+		"single Header": {
+			singleHeader,
+			net.ParseIP("192.168.100.5"),
+		},
+		"multiple Header": {
+			multipleHeader,
+			net.ParseIP("192.168.100.5"),
 		},
 	}
 

--- a/handlers/statsd.go
+++ b/handlers/statsd.go
@@ -46,9 +46,7 @@ func writeStatsdLog(w *statsd.Client, req *http.Request, url url.URL, ts time.Ti
 		"protocol:" + req.Proto,
 	}
 
-	msDur := float64(dur.Nanoseconds() / (int64(time.Millisecond) / int64(time.Nanosecond)))
-
-	w.TimeInMilliseconds("request.response_time", msDur, tags, 1)
+	w.Timing("request.response_time", dur, tags, 1)
 	w.Incr("request.count", tags, 1)
 }
 

--- a/handlers/statsd_test.go
+++ b/handlers/statsd_test.go
@@ -112,12 +112,12 @@ func TestStatsdHandler(t *testing.T) {
 		expected []string
 	}{
 		"simple get": {newRequest("GET", "http://example.com"), []string{
-			"service.test.request.response_time:0.000000|ms|#tag1,tag2:value,endpoint:/,statusCode:200,method:GET,protocol:HTTP/1.1",
-			"service.test.request.count:1|c|#tag1,tag2:value,endpoint:/,statusCode:200,method:GET,protocol:HTTP/1.1",
+			`service\.test\.request\.response_time\:[0-9.]+\|ms\|\#tag1\,tag2\:value\,endpoint\:\/\,statusCode\:200\,method\:GET\,protocol\:HTTP\/1\.1`,
+			`service\.test\.request\.count\:1\|c\|\#tag1\,tag2\:value\,endpoint\:\/\,statusCode\:200\,method\:GET\,protocol\:HTTP\/1\.1`,
 		}},
 		"post removes fields": {newRequest("POST", "http://example.com/token?apid=1"), []string{
-			"service.test.request.response_time:0.000000|ms|#tag1,tag2:value,endpoint:/token,statusCode:200,method:POST,protocol:HTTP/1.1",
-			"service.test.request.count:1|c|#tag1,tag2:value,endpoint:/token,statusCode:200,method:POST,protocol:HTTP/1.1",
+			`service\.test\.request\.response_time\:[0-9.]+\|ms\|\#tag1\,tag2\:value\,endpoint\:\/token\,statusCode\:200\,method\:POST\,protocol\:HTTP\/1\.1`,
+			`service\.test\.request\.count\:1\|c\|\#tag1\,tag2\:value\,endpoint\:\/token\,statusCode\:200\,method\:POST\,protocol\:HTTP\/1\.1`,
 		}},
 	}
 
@@ -145,7 +145,7 @@ func TestStatsdHandler(t *testing.T) {
 		assert.Equal(t, http.StatusOK, rec.Code)
 
 		for _, message := range tc.expected {
-			assert.Equal(t, message, <-done, "test: %s", k)
+			assert.Regexp(t, message, <-done, "test: %s", k)
 		}
 	}
 }

--- a/handlers/structured.go
+++ b/handlers/structured.go
@@ -38,7 +38,6 @@ func (h structuredHandler) writeLog(w LoggingResponseWriter, req *http.Request, 
 // dur is the time taken by the server to generate the response
 // status and size are used to provide response HTTP status and size
 func writeStructuredLog(w LoggingResponseWriter, logger log.Context, req *http.Request, url url.URL, ts time.Time, dur time.Duration, status, size int) {
-	sDur := float64(dur.Nanoseconds()) / (float64(time.Second) / float64(time.Nanosecond))
 	uri := parseURI(req, url)
 	ip := ""
 	if userIP, err := getUserIP(req); err == nil {
@@ -57,7 +56,7 @@ func writeStructuredLog(w LoggingResponseWriter, logger log.Context, req *http.R
 		"http.user":       ip,
 		"http.ref":        req.Referer(),
 		"http.user-agent": req.Header.Get("User-Agent"),
-		"dur":             sDur,
+		"dur":             dur.Seconds(),
 		"ts":              ts.Format(time.RFC3339Nano),
 	}).Infof("%s %s %s", req.Method, uri, req.Proto)
 }

--- a/handlers/structured_test.go
+++ b/handlers/structured_test.go
@@ -220,8 +220,7 @@ func TestStructuredLogging(t *testing.T) {
 		},
 	}
 
-	logger := log.New()
-	logger.Add(log.KV{"transaction": "test-123"})
+	logger := log.New().With(log.KV{"transaction": "test-123"})
 	hook := test.NewLocal(logger.Logger)
 	context := logger.With(log.KV{"module": "request.handler"})
 

--- a/handlers/structured_test.go
+++ b/handlers/structured_test.go
@@ -123,7 +123,7 @@ func TestStructuredLogging(t *testing.T) {
 				ProtoMinor: 0,
 				URL:        &url.URL{Host: "www.example.com:443"},
 				Host:       "www.example.com:443",
-				RemoteAddr: "192.168.100.5",
+				RemoteAddr: "192.168.100.5:9843",
 			},
 			now,
 			getDuration(t, "0.927s"),
@@ -142,7 +142,7 @@ func TestStructuredLogging(t *testing.T) {
 				"dur":             0.927,
 				"ts":              now.Format(time.RFC3339Nano),
 				"http.ref":        "",
-				"http.user":       "",
+				"http.user":       "192.168.100.5",
 				"http.user-agent": "",
 			},
 		},
@@ -234,7 +234,11 @@ func TestStructuredLogging(t *testing.T) {
 		assert.Equal(t, tc.message, hook.LastEntry().Message, "test %s - Has Message", k)
 		for f, v := range tc.fields {
 			assert.Contains(t, hook.LastEntry().Data, f, "test %s - Has Field: %s", k, f)
-			assert.Equal(t, v, hook.LastEntry().Data[f], "test %s - Field: %s", k, f)
+			if _, ok := v.(float64); ok {
+				assert.InDelta(t, v, hook.LastEntry().Data[f], 0.0001, "test %s - Field: %s", k, f)
+			} else {
+				assert.Equal(t, v, hook.LastEntry().Data[f], "test %s - Field: %s", k, f)
+			}
 		}
 	}
 }

--- a/log/exported.go
+++ b/log/exported.go
@@ -80,12 +80,6 @@ func Err(err error) *ContextEntry {
 	return logContext.Err(err)
 }
 
-// Add modifies the global context and returns itself
-func Add(fields KV) *ContextEntry {
-	logContext.Add(fields)
-	return logContext
-}
-
 // Fields will return the current set of fields in the global context
 func Fields() KV {
 	return logContext.Fields()


### PR DESCRIPTION
- Remove `.Add` and `.Merge` (always use `context.Context` to store a state to be passed around)
- Only store `log.KV` instead of an actual logger within the context
- Fix `getUserIP` (now works for RemoteAddr and if the header field is blank will ignore them
- StatsD reports duration in fractional seconds better (was rounding a bit too much before)
- Rename `GetLevel` to `Level` and update the interfaces