### PR TITLE
Rename structs/interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,14 @@
 
 [![Build Status](https://travis-ci.org/graze/golang-service.svg?branch=master)](https://travis-ci.org/graze/golang-service)
 
-- [Log](#log) Structured Contextual logging
+- [Log](#log) Structured logging
 - [Handlers](#handlers) http request middleware to add logging (healthd, context, statsd, structured logs)
 - [Metrics](#metrics) send monitoring metrics to collectors (currently: stats)
 - [NetTest](#nettest) helpers for use when testing networks
 
 ## Log
 
-Handle global logging with context. Based on [logrus](https://github.com/Sirupsen/logrus)
-with an option to create a global context.
+Handle global logging with context. Based on [logrus](https://github.com/Sirupsen/logrus) incorporating golang's `context.context`
 
 It uses [logfmt](https://brandur.org/logfmt) by default but can also output `json` using a `&logrus.JSONFormatter()`
 
@@ -71,8 +70,8 @@ The logger can use golang's context to pass around fields
 ```go
 logger := log.New()
 logger.Add(log.KV{"module": "request_handler"})
-context := logger.NewContext(context.Background())
-log.Ctx(context).
+ctx := logger.NewContext(context.Background())
+log.Ctx(ctx).
     With(log.KV{"tag": "received_request"}).
     Info("Received request")
 ```
@@ -86,12 +85,12 @@ The context can be applied to another local logger
 ```go
 logger := log.New()
 logger.Add(log.KV{"module": "request_handler"})
-context := logger.NewContext(context.Background())
+ctx := logger.NewContext(context.Background())
 
 logger2 := log.New()
 logger2.SetOutput(os.Stderr)
 logger2.Add(log.KV{"tag": "received_request"})
-logger2.Ctx(context).Info("Received request")
+logger2.Ctx(ctx).Info("Received request")
 ```
 
 ```

--- a/handlers/context.go
+++ b/handlers/context.go
@@ -19,7 +19,7 @@ import (
 
 // logContextHandler contains a local logger context and the handler
 type logContextHandler struct {
-	logger  log.Context
+	logger  log.FieldLogger
 	handler http.Handler
 }
 
@@ -62,6 +62,6 @@ func LogContextHandler(h http.Handler) http.Handler {
 }
 
 // LoggingContextHandler returns a handler that adds `http` and `transaction` items into the provided logging context
-func LoggingContextHandler(logger log.Context, h http.Handler) http.Handler {
+func LoggingContextHandler(logger log.FieldLogger, h http.Handler) http.Handler {
 	return logContextHandler{logger.With(log.KV{}), h}
 }

--- a/handlers/doc.go
+++ b/handlers/doc.go
@@ -27,11 +27,18 @@ Usage:
 They can also be manually chained together
     loggedRouter := handlers.StatsdHandler(handlers.HealthdHandler(r))
 
-Logging ContextEntry
+Logging Context
 
 This creates a logging context to be passed into the handling function with information about the request
 
 Usage:
+    r := mux.NewRouter()
+    r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+        log.Ctx(r.Context()).Info("log a message with the context")
+        w.Write([]byte("This is a catch-all route"))
+    })
+    loggedRouter := handlers.LogContextHandler(r)
+    http.ListenAndServe(":1123", loggedRouter)
 
 Healthd
 

--- a/handlers/structured.go
+++ b/handlers/structured.go
@@ -19,7 +19,7 @@ import (
 )
 
 type structuredHandler struct {
-	logger  log.Context
+	logger  log.FieldLogger
 	handler http.Handler
 }
 
@@ -37,7 +37,7 @@ func (h structuredHandler) writeLog(w LoggingResponseWriter, req *http.Request, 
 // ts is the timestamp with wich the entry should be logged
 // dur is the time taken by the server to generate the response
 // status and size are used to provide response HTTP status and size
-func writeStructuredLog(w LoggingResponseWriter, logger log.Context, req *http.Request, url url.URL, ts time.Time, dur time.Duration, status, size int) {
+func writeStructuredLog(w LoggingResponseWriter, logger log.FieldLogger, req *http.Request, url url.URL, ts time.Time, dur time.Duration, status, size int) {
 	uri := parseURI(req, url)
 	ip := ""
 	if userIP, err := getUserIP(req); err == nil {
@@ -77,7 +77,7 @@ func writeStructuredLog(w LoggingResponseWriter, logger log.Context, req *http.R
 //		log.With(log.KV{"module":"request.handler"})
 //		, r)
 //  http.ListenAndServe(":1123", loggedRouter)
-func StructuredLogHandler(logger log.Context, h http.Handler) http.Handler {
+func StructuredLogHandler(logger log.FieldLogger, h http.Handler) http.Handler {
 	return structuredHandler{logger, h}
 }
 

--- a/handlers/structured.go
+++ b/handlers/structured.go
@@ -70,11 +70,10 @@ func writeStructuredLog(w LoggingResponseWriter, logger log.FieldLogger, req *ht
 //  r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 //  	w.Write([]byte("This is a catch-all route"))
 //  })
-//  context := log.New()
-//	context.SetFormatter(&logrus.JSONFormatter{})
-//	context.Add(log.KV{"module":"request.handler"})
+//  logger := log.New()
+//	logger.SetFormatter(&logrus.JSONFormatter{})
 //  loggedRouter := handlers.StructuredLogHandler(
-//		log.With(log.KV{"module":"request.handler"})
+//		logger.With(log.KV{"module":"request.handler"})
 //		, r)
 //  http.ListenAndServe(":1123", loggedRouter)
 func StructuredLogHandler(logger log.FieldLogger, h http.Handler) http.Handler {

--- a/handlers/structured_test.go
+++ b/handlers/structured_test.go
@@ -222,13 +222,13 @@ func TestStructuredLogging(t *testing.T) {
 
 	logger := log.New().With(log.KV{"transaction": "test-123"})
 	hook := test.NewLocal(logger.Logger)
-	context := logger.With(log.KV{"module": "request.handler"})
+	local := logger.With(log.KV{"module": "request.handler"})
 
 	for k, tc := range cases {
 		hook.Reset()
 		rec := httptest.NewRecorder()
 		responseLogger := &responseLogger{w: rec}
-		writeStructuredLog(responseLogger, context, tc.request, *tc.request.URL, tc.timestamp, tc.duration, http.StatusOK, tc.size)
+		writeStructuredLog(responseLogger, local, tc.request, *tc.request.URL, tc.timestamp, tc.duration, http.StatusOK, tc.size)
 		assert.Equal(t, 1, len(hook.Entries), "test %s - Has Log Entry", k)
 		assert.Equal(t, log.InfoLevel, hook.LastEntry().Level, "test %s - Has Log Level", k)
 		assert.Equal(t, tc.message, hook.LastEntry().Message, "test %s - Has Message", k)

--- a/log/context.go
+++ b/log/context.go
@@ -33,7 +33,6 @@ type KV logrus.Fields
 type FieldLogger interface {
 	Ctx(ctx context.Context) *LoggerEntry
 	NewContext(ctx context.Context) context.Context
-	AppendContext(ctx context.Context, fields KV) context.Context
 
 	With(fields KV) *LoggerEntry
 	Err(err error) *LoggerEntry
@@ -76,11 +75,6 @@ func (c *LoggerEntry) Ctx(ctx context.Context) *LoggerEntry {
 		return c.With(fields)
 	}
 	return c.With(KV{})
-}
-
-// AppendContext will append the fields to the ctx and return a new context.Context
-func (c *LoggerEntry) AppendContext(ctx context.Context, fields KV) context.Context {
-	return c.Ctx(ctx).With(fields).NewContext(ctx)
 }
 
 // With creates a new LoggerEntry and adds the fields to it

--- a/log/context_test.go
+++ b/log/context_test.go
@@ -51,11 +51,11 @@ func TestMergeContext(t *testing.T) {
 func testImplements(t *testing.T) {
 	logger := New()
 	assert.Implements(t, (*Logger)(nil), logger)
-	assert.Implements(t, (*Context)(nil), logger)
+	assert.Implements(t, (*FieldLogger)(nil), logger)
 
 	local := logger.With(KV{"k": "v"})
-	assert.Implements(t, (*Context)(nil), local)
+	assert.Implements(t, (*FieldLogger)(nil), local)
 
 	global := With(KV{"k": "v"})
-	assert.Implements(t, (*Context)(nil), global)
+	assert.Implements(t, (*FieldLogger)(nil), global)
 }

--- a/log/doc.go
+++ b/log/doc.go
@@ -76,9 +76,9 @@ This logger supports golang's `Context`. You can create a new context and use an
 
     logger := log.New()
     logger.Add(log.KV{"key":"value"})
-    context := logger.NewContext(context.Background())
+    ctx := logger.NewContext(context.Background())
 
-    log.Ctx(context).Info("text")
+    log.Ctx(ctx).Info("text")
 
     // key=value level=info msg=text
 
@@ -86,11 +86,11 @@ You can use a logging context stored within a `context.Context` with a second lo
 
     logger := log.New()
     logger.Add(log.KV{"key":"value"})
-    context := logger.NewContext(context.Background())
+    ctx := logger.NewContext(context.Background())
 
     logger2 := log.New()
     logger2.Add(log.KV{"key2":"value2"})
-    logger2.Ctx(context).Info("text")
+    logger2.Ctx(ctx).Info("text")
 
     // key=value key2=value2 level=info msg=text
 

--- a/log/exported.go
+++ b/log/exported.go
@@ -46,91 +46,96 @@ const logKey key = 0
 
 // SetOutput sets the standard logger output.
 func SetOutput(out io.Writer) {
-	logContext.SetOutput(out)
+	logEntry.SetOutput(out)
 }
 
 // SetFormatter sets the standard logger formatter.
 func SetFormatter(formatter logrus.Formatter) {
-	logContext.SetFormatter(formatter)
+	logEntry.SetFormatter(formatter)
 }
 
 // SetLevel sets the standard logger level.
 func SetLevel(level logrus.Level) {
-	logContext.SetLevel(level)
+	logEntry.SetLevel(level)
 }
 
 // Level returns the standard logger level.
 func Level() logrus.Level {
-	return logContext.Level()
+	return logEntry.Level()
 }
 
 // AddHook adds a new hook to the global logging context
 func AddHook(hook logrus.Hook) {
-	logContext.AddHook(hook)
+	logEntry.AddHook(hook)
 }
 
-// With returns a new ContextEntry with the supplied fields
-func With(fields KV) *ContextEntry {
-	return logContext.With(fields)
+// With returns a new LoggerEntry with the supplied fields
+func With(fields KV) *LoggerEntry {
+	return logEntry.With(fields)
 }
 
-// Err creates a new ContextEntry from the standard logger and adds an error
+// Err creates a new LoggerEntry from the standard logger and adds an error
 // to it, using the value defined in ErrorKey as key.
-func Err(err error) *ContextEntry {
-	return logContext.Err(err)
+func Err(err error) *LoggerEntry {
+	return logEntry.Err(err)
 }
 
 // Fields will return the current set of fields in the global context
 func Fields() KV {
-	return logContext.Fields()
+	return logEntry.Fields()
 }
 
 // Ctx will use the provided context with its logs if applicable
-func Ctx(ctx context.Context) *ContextEntry {
-	return logContext.Ctx(ctx)
+func Ctx(ctx context.Context) *LoggerEntry {
+	return logEntry.Ctx(ctx)
 }
 
-// NewContext adds the current `logContext` into `ctx`
+// NewContext adds the current `logEntry` into `ctx`
 func NewContext(ctx context.Context) context.Context {
-	return logContext.NewContext(ctx)
+	return logEntry.NewContext(ctx)
+}
+
+// AppendContext will add the fields into the supplied ctx
+func AppendContext(ctx context.Context, fields KV) context.Context {
+	return logEntry.AppendContext(ctx, fields)
 }
 
 // Debug logs a message at level Debug on the standard logger.
 func Debug(args ...interface{}) {
-	logContext.Debug(args...)
+	logEntry.Debug(args...)
 }
 
 // Print logs a message at level Info on the standard logger.
 func Print(args ...interface{}) {
-	logContext.Print(args...)
+	logEntry.Print(args...)
 }
 
 // Info logs a message at level Info on the standard logger.
 func Info(args ...interface{}) {
-	logContext.Info(args...)
+	logEntry.Info(args...)
 }
 
 // Error logs a message at level Error on the standard logger.
 func Error(args ...interface{}) {
-	logContext.Error(args...)
+	logEntry.Error(args...)
 }
 
 // Debugf logs a message at level Debug on the standard logger.
 func Debugf(format string, args ...interface{}) {
-	logContext.Debugf(format, args...)
+	logEntry.Debugf(format, args...)
 }
 
 // Printf logs a message at level Info on the standard logger.
 func Printf(format string, args ...interface{}) {
-	logContext.Printf(format, args...)
+	logEntry.Printf(format, args...)
 }
 
 // Infof logs a message at level Info on the standard logger.
 func Infof(format string, args ...interface{}) {
-	logContext.Infof(format, args...)
+	logEntry.Infof(format, args...)
 }
 
 // Errorf logs a message at level Error on the standard logger.
 func Errorf(format string, args ...interface{}) {
-	logContext.Errorf(format, args...)
+	logEntry.Errorf(format, args...)
 }

--- a/log/exported.go
+++ b/log/exported.go
@@ -95,11 +95,6 @@ func NewContext(ctx context.Context) context.Context {
 	return logEntry.NewContext(ctx)
 }
 
-// AppendContext will add the fields into the supplied ctx
-func AppendContext(ctx context.Context, fields KV) context.Context {
-	return logEntry.AppendContext(ctx, fields)
-}
-
 // Debug logs a message at level Debug on the standard logger.
 func Debug(args ...interface{}) {
 	logEntry.Debug(args...)

--- a/log/logging_test.go
+++ b/log/logging_test.go
@@ -67,11 +67,11 @@ func TestGlobalConfiguration(t *testing.T) {
 	assert.Equal(t, InfoLevel, logger.Logger.Level)
 	assert.IsType(t, (*logrus.TextFormatter)(nil), logger.Logger.Formatter)
 
-	context := With(KV{})
+	logger2 := With(KV{})
 
-	assert.Equal(t, os.Stdout, context.Logger.Out)
-	assert.Equal(t, DebugLevel, context.Logger.Level)
-	assert.IsType(t, (*logrus.JSONFormatter)(nil), context.Logger.Formatter)
+	assert.Equal(t, os.Stdout, logger2.Logger.Out)
+	assert.Equal(t, DebugLevel, logger2.Logger.Level)
+	assert.IsType(t, (*logrus.JSONFormatter)(nil), logger2.Logger.Formatter)
 }
 
 func TestModificationOfContextLogger(t *testing.T) {


### PR DESCRIPTION
The name of the structures and interfaces made sense before `context.Context` came along. Now though it sort of conflicts.

- Renames `log.Context` -> `log.FieldLogger`
- Renames `log.ContextEntry` -> `log.LoggerEntry`