### PR TITLE
Log level env

### DIFF
--- a/log/context.go
+++ b/log/context.go
@@ -19,9 +19,10 @@ import (
 )
 
 var (
-	logEntry = New()
-	appName  = "LOG_APPLICATION"
-	envName  = "ENVIRONMENT"
+	logEntry  = New()
+	appName   = "LOG_APPLICATION"
+	envName   = "ENVIRONMENT"
+	levelName = "LOG_LEVEL"
 )
 
 // KV is a shorthand for logrus.Fields so less text is required to be typed:
@@ -138,6 +139,17 @@ func New() (context *LoggerEntry) {
 	}
 	if env := os.Getenv(envName); env != "" {
 		fields["env"] = env
+	}
+	if level := os.Getenv(levelName); level != "" {
+		if l, err := logrus.ParseLevel(level); err == nil {
+			context.SetLevel(l)
+		} else {
+			context.Err(err).With(KV{
+				"module":   "log_initialisation",
+				"tag":      "log_new_failed",
+				"logLevel": level,
+			}).Error("The supplied log level is invalid")
+		}
 	}
 	context = context.With(fields)
 	return

--- a/log/context_test.go
+++ b/log/context_test.go
@@ -67,6 +67,7 @@ func TestNewWithValidLogLevels(t *testing.T) {
 		level    string
 		expected logrus.Level
 	}{
+		"blank":      {"", logrus.InfoLevel},
 		"lower case": {"info", logrus.InfoLevel},
 		"upper case": {"INFO", logrus.InfoLevel},
 		"mixed case": {"InFo", logrus.InfoLevel},

--- a/log/context_test.go
+++ b/log/context_test.go
@@ -11,8 +11,10 @@
 package log
 
 import (
+	"os"
 	"testing"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/Sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 )
@@ -58,4 +60,45 @@ func testImplements(t *testing.T) {
 
 	global := With(KV{"k": "v"})
 	assert.Implements(t, (*FieldLogger)(nil), global)
+}
+
+func TestNewWithValidLogLevels(t *testing.T) {
+	cases := map[string]struct {
+		level    string
+		expected logrus.Level
+	}{
+		"lower case": {"info", logrus.InfoLevel},
+		"upper case": {"INFO", logrus.InfoLevel},
+		"mixed case": {"InFo", logrus.InfoLevel},
+		"debug":      {"debug", logrus.DebugLevel},
+		"panic":      {"panic", logrus.PanicLevel},
+		"warn":       {"warn", logrus.WarnLevel},
+		"warning":    {"warning", logrus.WarnLevel},
+		"fatal":      {"fatal", logrus.FatalLevel},
+		"error":      {"error", logrus.ErrorLevel},
+	}
+
+	for k, tc := range cases {
+		os.Setenv("LOG_LEVEL", tc.level)
+		logger := New()
+		assert.Equal(t, tc.expected, logger.Level(), "test: %s", k)
+	}
+	os.Setenv("LOG_LEVEL", "")
+}
+
+func TestNewWithInvalidLogLEvels(t *testing.T) {
+	cases := map[string]struct {
+		level    string
+		expected logrus.Level
+	}{
+		"plural": {"infos", logrus.InfoLevel},
+		"crit":   {"crit", logrus.InfoLevel},
+	}
+
+	for k, tc := range cases {
+		os.Setenv("LOG_LEVEL", tc.level)
+		logger := New()
+		assert.Equal(t, tc.expected, logger.Level(), "test: %s", k)
+	}
+	os.Setenv("LOG_LEVEL", "")
 }


### PR DESCRIPTION
Adds the environment variable: `LOG_LEVEL` to set the currently logging level, so we can log at debug on the test/staging/integration server etc.