### PR TITLE
Add Validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 DOCKER_CMD=docker-compose run --rm local
 MOUNT=/go/src/github.com/graze/golang-service
-CODE=./handlers ./log ./metrics ./nettest
+CODE=./handlers ./log ./metrics ./nettest ./validate
 
 build-cli: ## Build the local image
 	docker-compose build local
@@ -33,11 +33,13 @@ lint: ## Run gofmt and goimports in lint mode
 	${DOCKER_CMD} golint -set_exit_status ./log/...
 	${DOCKER_CMD} golint -set_exit_status ./metrics/...
 	${DOCKER_CMD} golint -set_exit_status ./nettest/...
+	${DOCKER_CMD} golint -set_exit_status ./validate/...
 	${DOCKER_CMD} golint -set_exit_status ./
 	${DOCKER_CMD} go tool vet ./handlers
 	${DOCKER_CMD} go tool vet ./log
 	${DOCKER_CMD} go tool vet ./metrics
 	${DOCKER_CMD} go tool vet ./nettest
+	${DOCKER_CMD} go tool vet ./validate
 
 format: ## Run gofmt to format the code
 	${DOCKER_CMD} gofmt -s -w ${CODE}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - [Handlers](#handlers) http request middleware to add logging (healthd, context, statsd, structured logs)
 - [Metrics](#metrics) send monitoring metrics to collectors (currently: stats)
 - [NetTest](#nettest) helpers for use when testing networks
+- [Validation](#validation) to ensure the user input is correct
 
 ## Log
 
@@ -254,6 +255,46 @@ s, err := net.Dial("tcp", addr.String())
 fmt.Fprintf(s, msg + "\n")
 if msg = "\n" != <-done {
     panic("message mismatch")
+}
+```
+
+## Validation
+
+A very simple validation for user input
+
+```bash
+$ go get github.com/graze/golang-service/validate
+```
+
+It uses the interface: `Validator` containing the method `Validate` which will return an error if the item is not valid
+
+```go
+type Validator interface {
+    Validate(ctx context.Context) error
+}
+```
+
+```go
+type Item struct {
+    Name        string `json:"name"`
+    Description string `json:"description"`
+    Winning     bool   `json:"winning"`
+}
+func (i Item) Validate(ctx context.Context) error {
+    if utf8.RuneCountInString(i.Name) <= 3 {
+        return fmt.Errorf("field: name must have more than 3 characters")
+    }
+    return nil
+}
+
+func CreateItem(w http.ResponseWriter, r *http.Request) {
+    item := &Item{}
+    if err := validate.JsonRequest(ctx, r, item); err != nil {
+        w.WriteHeader(400)
+        return
+    }
+
+    // item.Name, item.Description, item.Winning etc...
 }
 ```
 

--- a/doc.go
+++ b/doc.go
@@ -20,5 +20,7 @@ The metrics package prodives helpers for statsd
 The handlers package provides a set of handlers that handle http.Request log the results
 
 The nettest package provides a set of helpers for use when testing networks
+
+The validate package provides input validate for user requests
 */
 package golangservice

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -1,0 +1,120 @@
+// This file is part of graze/golang-service
+//
+// Copyright (c) 2016 Nature Delivered Ltd. <https://www.graze.com>
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+//
+// license: https://github.com/graze/golang-service/blob/master/LICENSE
+// link:    https://github.com/graze/golang-service
+
+/*
+Package validate provides a simple interface for validating JSON user input
+
+Example:
+
+	type Item struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}
+
+    func (i *Item) Validate(ctx context.Context) error {
+		if RuneCountInString(i.Name) == 0 {
+			return fmt.Errorf("the field: name must be provided and not empty")
+		}
+		return nil
+	}
+
+	func CreateItem(w http.ResponseWriter, r *http.Request) {
+		item := &Item{}
+		if err := validate.JsonRequest(ctx, r, item); err != nil {
+			w.WriteHeader(400)
+			return
+		}
+	}
+*/
+package validate
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+type (
+	// IOError for when we fail to read the stream
+	IOError struct{ error }
+)
+
+// Validatable items can self validate
+type Validatable interface {
+	Validate(ctx context.Context) error
+}
+
+// JsonRequest takes an http request, decodes the json and validates the input against a Validatable output
+// the Validatable variable will get populated with the contents of the body provided by *http.Request
+//
+// Usage:
+// 	type Item struct {
+//		Name string `json:"name"`
+//		Description string `json:"description"`
+//	}
+//
+//	func (i *Item) Validate(ctx context.Context) error {
+//		if RuneCountInString(i.Name) == 0 {
+//			return fmt.Errorf("the field: name must be provided and not empty")
+//		}
+//		return nil
+//	}
+//
+//	func CreateItem(w http.ResponseWriter, r *http.Request) {
+//		item := &Item{}
+//		if err := validate.JsonRequest(ctx, r, item); err != nil {
+//			w.WriteHeader(400)
+//			return
+//		}
+//	}
+func JsonRequest(ctx context.Context, r *http.Request, v Validatable) error {
+	return Reader(ctx, r.Body, json.Unmarshal, v)
+}
+
+// XmlRequest takes an http request docodes the xml into an item and validates the provided item
+func XmlRequest(ctx context.Context, r *http.Request, v Validatable) error {
+	return Reader(ctx, r.Body, xml.Unmarshal, v)
+}
+
+// ReadAndValidate takes a generic io.Reader, an unmarshaller  and validates the input against a Validatable item
+// the Validatable variable will get populated with the contents of the body provided by *http.Request
+//
+// Usage:
+// 	type ApiInput struct {
+//		Name string `json:"name"`
+//		Description string `json:"description"`
+//	}
+//
+//  func (i *ApiInput) Validate(ctx context.Context) error {
+//		if RuneCountInString(i.Name) == 0 {
+//			return fmt.Errorf("the field: name must be provided and not empty")
+//		}
+//		return nil
+//	}
+//
+//	func main() {
+//		input := &ApiInput{}
+//		if err := validate.Reader(ctx, reader, json.Unmarshal, input); err != nil {
+//			log.Panic(err)
+//		}
+//	}
+func Reader(ctx context.Context, r io.Reader, unmarshaller func(data []byte, v interface{}) error, v Validatable) error {
+	str, err := ioutil.ReadAll(r)
+	if err != nil {
+		return &IOError{err}
+	}
+	if err = unmarshaller(str, v); err != nil {
+		return err
+	}
+	return v.Validate(ctx)
+}

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -27,7 +27,7 @@ Example:
 
 	func CreateItem(w http.ResponseWriter, r *http.Request) {
 		item := &Item{}
-		if err := validate.JsonRequest(ctx, r, item); err != nil {
+		if err := validate.JSONRequest(ctx, r, item); err != nil {
 			w.WriteHeader(400)
 			return
 		}
@@ -54,8 +54,14 @@ type Validatable interface {
 	Validate(ctx context.Context) error
 }
 
-// JsonRequest takes an http request, decodes the json and validates the input against a Validatable output
+// JSONRequest takes an http request, decodes the json and validates the input against a Validatable output
 // the Validatable variable will get populated with the contents of the body provided by *http.Request
+//
+// The base set of error types returned from this method are:
+// 	validate.IOError
+//  *json.SyntaxError
+//	*json.UnmarshalFieldError
+//	*json.UnmarshalTypeError
 //
 // Usage:
 // 	type Item struct {
@@ -72,21 +78,27 @@ type Validatable interface {
 //
 //	func CreateItem(w http.ResponseWriter, r *http.Request) {
 //		item := &Item{}
-//		if err := validate.JsonRequest(ctx, r, item); err != nil {
+//		if err := validate.JSONRequest(ctx, r, item); err != nil {
 //			w.WriteHeader(400)
 //			return
 //		}
 //	}
-func JsonRequest(ctx context.Context, r *http.Request, v Validatable) error {
+func JSONRequest(ctx context.Context, r *http.Request, v Validatable) error {
 	return Reader(ctx, r.Body, json.Unmarshal, v)
 }
 
-// XmlRequest takes an http request docodes the xml into an item and validates the provided item
-func XmlRequest(ctx context.Context, r *http.Request, v Validatable) error {
+// XMLRequest takes an http request docodes the xml into an item and validates the provided item
+//
+// The base set of error types returned from this method are:
+// 	validate.IOError
+//  *xml.SyntaxError
+//	*xml.TagPathError
+//	*xml.UnmarshalError
+func XMLRequest(ctx context.Context, r *http.Request, v Validatable) error {
 	return Reader(ctx, r.Body, xml.Unmarshal, v)
 }
 
-// ReadAndValidate takes a generic io.Reader, an unmarshaller  and validates the input against a Validatable item
+// Reader takes a generic io.Reader, an unmarshaller  and validates the input against a Validatable item
 // the Validatable variable will get populated with the contents of the body provided by *http.Request
 //
 // Usage:
@@ -96,7 +108,7 @@ func XmlRequest(ctx context.Context, r *http.Request, v Validatable) error {
 //	}
 //
 //  func (i *ApiInput) Validate(ctx context.Context) error {
-//		if RuneCountInString(i.Name) == 0 {
+//		if utf8.RuneCountInString(i.Name) == 0 {
 //			return fmt.Errorf("the field: name must be provided and not empty")
 //		}
 //		return nil

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -33,12 +33,12 @@ func (t *TypesStruct) Validate(ctx context.Context) error {
 	return nil
 }
 
-type XmlStruct struct {
+type XMLStruct struct {
 	Name   string `XmlName:"name"`
 	Drinks int    `XmlName:"drinks"`
 }
 
-func (x *XmlStruct) Validate(ctx context.Context) error {
+func (x *XMLStruct) Validate(ctx context.Context) error {
 	return nil
 }
 
@@ -98,7 +98,7 @@ func TestReader(t *testing.T) {
 		"xml validation": {
 			`<XmlStruct><Name>bob</Name><Drinks>12</Drinks></XmlStruct>`,
 			xml.Unmarshal,
-			&XmlStruct{},
+			&XMLStruct{},
 			false,
 			"",
 		},
@@ -137,7 +137,7 @@ func TestJsonRequest(t *testing.T) {
 	}
 
 	for k, tc := range cases {
-		err := JsonRequest(context.Background(), tc.Request, tc.Struct)
+		err := JSONRequest(context.Background(), tc.Request, tc.Struct)
 		assert.Equal(t, tc.Errored, err != nil, "test: %s", k)
 		if tc.Errored {
 			assert.Equal(t, tc.Expected, err.Error(), "test: %s", k)
@@ -154,14 +154,14 @@ func TestXmlRequest(t *testing.T) {
 	}{
 		"xml validation": {
 			newRequest(t, "POST", "/thing", `<XmlStruct><Name>bob</Name><Drinks>12</Drinks></XmlStruct>`),
-			&XmlStruct{},
+			&XMLStruct{},
 			false,
 			"",
 		},
 	}
 
 	for k, tc := range cases {
-		err := XmlRequest(context.Background(), tc.Request, tc.Struct)
+		err := XMLRequest(context.Background(), tc.Request, tc.Struct)
 		assert.Equal(t, tc.Errored, err != nil, "test: %s", k)
 		if tc.Errored {
 			assert.Equal(t, tc.Expected, err.Error(), "test: %s", k)

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -1,0 +1,170 @@
+// This file is part of graze/golang-service
+//
+// Copyright (c) 2016 Nature Delivered Ltd. <https://www.graze.com>
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+//
+// license: https://github.com/graze/golang-service/blob/master/LICENSE
+// link:    https://github.com/graze/golang-service
+
+package validate
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type TypesStruct struct {
+	Number int               `json:"int" XMLName:"int"`
+	Text   string            `json:"string" XMLName:"string"`
+	Arr    []string          `json:"array" XMLName:"array"`
+	Obj    map[string]string `json:"object" XMLName:"object"`
+}
+
+func (t *TypesStruct) Validate(ctx context.Context) error {
+	return nil
+}
+
+type XmlStruct struct {
+	Name   string `XmlName:"name"`
+	Drinks int    `XmlName:"drinks"`
+}
+
+func (x *XmlStruct) Validate(ctx context.Context) error {
+	return nil
+}
+
+type FailureStruct map[string]interface{}
+
+func (s *FailureStruct) Validate(ctx context.Context) error {
+	return errors.New("this is not valid")
+}
+
+func newRequest(t *testing.T, method, path, body string) *http.Request {
+	req, err := http.NewRequest(method, path, strings.NewReader(body))
+	if err != nil {
+		t.Errorf("Failed to create a request")
+		t.Fail()
+	}
+
+	return req
+}
+
+func TestReader(t *testing.T) {
+	cases := map[string]struct {
+		Data         string
+		Unmarshaller func(data []byte, v interface{}) error
+		Struct       Validatable
+		Errored      bool
+		Expected     string
+	}{
+		"base": {
+			`
+{
+"int": 1,
+"string": "thing",
+"array": ["a","b"],
+"object": {
+"child": "thing"
+}
+}`,
+			json.Unmarshal,
+			&TypesStruct{},
+			false,
+			"",
+		},
+		"invalid json": {
+			`{"some":"text",}`,
+			json.Unmarshal,
+			&TypesStruct{},
+			true,
+			"invalid character '}' looking for beginning of object key string",
+		},
+		"fails validation": {
+			`{"some":"text"}`,
+			json.Unmarshal,
+			&FailureStruct{},
+			true,
+			"this is not valid",
+		},
+		"xml validation": {
+			`<XmlStruct><Name>bob</Name><Drinks>12</Drinks></XmlStruct>`,
+			xml.Unmarshal,
+			&XmlStruct{},
+			false,
+			"",
+		},
+	}
+
+	for k, tc := range cases {
+		err := Reader(context.Background(), strings.NewReader(tc.Data), tc.Unmarshaller, tc.Struct)
+		assert.Equal(t, tc.Errored, err != nil, "test: %s", k)
+		if tc.Errored {
+			assert.Equal(t, tc.Expected, err.Error(), "test: %s", k)
+		}
+	}
+}
+
+func TestJsonRequest(t *testing.T) {
+	cases := map[string]struct {
+		Request  *http.Request
+		Struct   Validatable
+		Errored  bool
+		Expected string
+	}{
+		"base": {
+			newRequest(t, "POST", "/thing", `
+{
+"int": 1,
+"string": "thing",
+"array": ["a","b"],
+"object": {
+"child": "thing"
+}
+}`),
+			&TypesStruct{},
+			false,
+			"",
+		},
+	}
+
+	for k, tc := range cases {
+		err := JsonRequest(context.Background(), tc.Request, tc.Struct)
+		assert.Equal(t, tc.Errored, err != nil, "test: %s", k)
+		if tc.Errored {
+			assert.Equal(t, tc.Expected, err.Error(), "test: %s", k)
+		}
+	}
+}
+
+func TestXmlRequest(t *testing.T) {
+	cases := map[string]struct {
+		Request  *http.Request
+		Struct   Validatable
+		Errored  bool
+		Expected string
+	}{
+		"xml validation": {
+			newRequest(t, "POST", "/thing", `<XmlStruct><Name>bob</Name><Drinks>12</Drinks></XmlStruct>`),
+			&XmlStruct{},
+			false,
+			"",
+		},
+	}
+
+	for k, tc := range cases {
+		err := XmlRequest(context.Background(), tc.Request, tc.Struct)
+		assert.Equal(t, tc.Errored, err != nil, "test: %s", k)
+		if tc.Errored {
+			assert.Equal(t, tc.Expected, err.Error(), "test: %s", k)
+		}
+	}
+}


### PR DESCRIPTION
Uses the interface: `Validator` to implement: `func Validate(ctx context.Context) error`

- Adds `validate.JSONRequest` - validate a request containing json data, and unmarshal into a type which has its own validation
- Adds `validate.XMLRequest` - validate a request containing xml data and unmarshal into a type which has its own validation
- Adds `validate.Reader` - validate a `io.Reader` using a generic `Unmarshaler` into a type which has its own validateion