### PR TITLE
Return interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
   - docker
 
 env:
+  - ver=1.8-alpine
   - ver=1.7-alpine
   - ver=alpine
 

--- a/handlers/context.go
+++ b/handlers/context.go
@@ -25,13 +25,12 @@ type logContextHandler struct {
 
 // ServeHTTP modifies the context of the request by adding a local logger context
 func (h logContextHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	logger := h.logger.Ctx(req.Context())
 	url := *req.URL
 	ip := ""
 	if userIP, err := getUserIP(req); err == nil {
 		ip = userIP.String()
 	}
-	newContext := logger.With(log.KV{
+	ctx := h.logger.Ctx(req.Context()).With(log.KV{
 		"transaction":     uuid.NewV4().String(),
 		"http.method":     req.Method,
 		"http.protocol":   req.Proto,
@@ -42,7 +41,7 @@ func (h logContextHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		"http.ref":        req.Referer(),
 		"http.user-agent": req.Header.Get("User-Agent"),
 	}).NewContext(req.Context())
-	h.handler.ServeHTTP(w, req.WithContext(newContext))
+	h.handler.ServeHTTP(w, req.WithContext(ctx))
 }
 
 // LogContextHandler returns a handler that adds `http` and `transaction` items into a common logging context

--- a/handlers/context_test.go
+++ b/handlers/context_test.go
@@ -194,12 +194,16 @@ func TestItUsesTheExistingRequestContext(t *testing.T) {
 	req = req.WithContext(context.WithValue(req.Context(), keyOne, "bar"))
 	req = req.WithContext(context.WithValue(req.Context(), keyTwo, "foo"))
 
+	logger := log.With(log.KV{"key": "value"})
+
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "bar", r.Context().Value(keyOne))
 		assert.Equal(t, "foo", r.Context().Value(keyTwo))
-		assert.Equal(t, "GET", log.Ctx(r.Context()).Fields()["http.method"])
+		fields := log.Ctx(r.Context()).Fields()
+		assert.Equal(t, "GET", fields["http.method"])
+		assert.Equal(t, "value", fields["key"])
 	})
 
-	handler := LogContextHandler(h)
+	handler := LoggingContextHandler(logger, h)
 	handler.ServeHTTP(rec, req)
 }

--- a/handlers/context_test.go
+++ b/handlers/context_test.go
@@ -11,6 +11,7 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -163,14 +164,14 @@ func TestContextUpdatesTheRequestContext(t *testing.T) {
 
 	for k, tc := range cases {
 		beforeHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			entry := log.Ctx(req.Context())
+			fields := log.Ctx(req.Context()).Fields()
 			for f, v := range tc.expected {
-				assert.Contains(t, entry.Data, f, "test %s - Has Field: %s", k, f)
-				assert.Equal(t, v, entry.Data[f], "test %s - Field: %s", k, f)
+				assert.Contains(t, fields, f, "test %s - Has Field: %s", k, f)
+				assert.Equal(t, v, fields[f], "test %s - Field: %s", k, f)
 			}
 			for f, v := range tc.regex {
-				assert.Contains(t, entry.Data, f, "test %s - Has Field: %s", k, f)
-				assert.Regexp(t, v, entry.Data[f], "test %s - Field: %s", k, f)
+				assert.Contains(t, fields, f, "test %s - Has Field: %s", k, f)
+				assert.Regexp(t, v, fields[f], "test %s - Field: %s", k, f)
 			}
 			w.Write([]byte("ok\n"))
 		})
@@ -178,4 +179,20 @@ func TestContextUpdatesTheRequestContext(t *testing.T) {
 		handler := LogContextHandler(beforeHandler)
 		handler.ServeHTTP(rec, tc.request)
 	}
+}
+
+func TestItUsesTheExistingRequestContext(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := newRequest("GET", "/stuff")
+	req = req.WithContext(context.WithValue(req.Context(), "foo", "bar"))
+	req = req.WithContext(context.WithValue(req.Context(), 0, "foo"))
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "bar", r.Context().Value("foo"))
+		assert.Equal(t, "foo", r.Context().Value(0))
+		assert.Equal(t, "GET", log.Ctx(r.Context()).Fields()["http.method"])
+	})
+
+	handler := LogContextHandler(h)
+	handler.ServeHTTP(rec, req)
 }

--- a/handlers/context_test.go
+++ b/handlers/context_test.go
@@ -181,15 +181,22 @@ func TestContextUpdatesTheRequestContext(t *testing.T) {
 	}
 }
 
+type someKey int
+
+const (
+	keyOne someKey = iota
+	keyTwo
+)
+
 func TestItUsesTheExistingRequestContext(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := newRequest("GET", "/stuff")
-	req = req.WithContext(context.WithValue(req.Context(), "foo", "bar"))
-	req = req.WithContext(context.WithValue(req.Context(), 0, "foo"))
+	req = req.WithContext(context.WithValue(req.Context(), keyOne, "bar"))
+	req = req.WithContext(context.WithValue(req.Context(), keyTwo, "foo"))
 
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "bar", r.Context().Value("foo"))
-		assert.Equal(t, "foo", r.Context().Value(0))
+		assert.Equal(t, "bar", r.Context().Value(keyOne))
+		assert.Equal(t, "foo", r.Context().Value(keyTwo))
 		assert.Equal(t, "GET", log.Ctx(r.Context()).Fields()["http.method"])
 	})
 

--- a/handlers/structured_test.go
+++ b/handlers/structured_test.go
@@ -221,7 +221,11 @@ func TestStructuredLogging(t *testing.T) {
 	}
 
 	logger := log.New().With(log.KV{"transaction": "test-123"})
-	hook := test.NewLocal(logger.Logger)
+	base, ok := logger.(*log.LoggerEntry)
+	if !ok {
+		t.Error("Unable to cast logger to log.LoggerEntry")
+	}
+	hook := test.NewLocal(base.Logger)
 	local := logger.With(log.KV{"module": "request.handler"})
 
 	for k, tc := range cases {

--- a/log/context.go
+++ b/log/context.go
@@ -50,12 +50,29 @@ type FieldLogger interface {
 	Debugf(format string, args ...interface{})
 	Infof(format string, args ...interface{})
 	Printf(format string, args ...interface{})
+	Warnf(format string, args ...interface{})
+	Warningf(format string, args ...interface{})
 	Errorf(format string, args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Panicf(format string, args ...interface{})
 
 	Debug(args ...interface{})
 	Info(args ...interface{})
 	Print(args ...interface{})
+	Warn(args ...interface{})
+	Warning(args ...interface{})
 	Error(args ...interface{})
+	Fatal(args ...interface{})
+	Panic(args ...interface{})
+
+	Debugln(args ...interface{})
+	Infoln(args ...interface{})
+	Println(args ...interface{})
+	Warnln(args ...interface{})
+	Warningln(args ...interface{})
+	Errorln(args ...interface{})
+	Fatalln(args ...interface{})
+	Panicln(args ...interface{})
 }
 
 // Logger represents a struct that can modify the output of a log

--- a/log/context.go
+++ b/log/context.go
@@ -38,10 +38,10 @@ type KV logrus.Fields
 
 // FieldLogger represents a Logging FieldLogger
 type FieldLogger interface {
-	Ctx(ctx context.Context) FieldLogger
 	NewContext(ctx context.Context) context.Context
 	AppendContext(ctx context.Context, fields KV) context.Context
 
+	Ctx(ctx context.Context) FieldLogger
 	With(fields KV) FieldLogger
 	Err(err error) FieldLogger
 

--- a/log/context.go
+++ b/log/context.go
@@ -25,6 +25,12 @@ var (
 	levelName = "LOG_LEVEL"
 )
 
+// key is a type to ensure unique key for context
+type key int
+
+// LogKey is the key used for context
+const logKey key = iota
+
 // KV is a shorthand for logrus.Fields so less text is required to be typed:
 //
 // 	log.With(log.KV{"k":"v"})
@@ -32,12 +38,12 @@ type KV logrus.Fields
 
 // FieldLogger represents a Logging FieldLogger
 type FieldLogger interface {
-	Ctx(ctx context.Context) *LoggerEntry
+	Ctx(ctx context.Context) FieldLogger
 	NewContext(ctx context.Context) context.Context
 	AppendContext(ctx context.Context, fields KV) context.Context
 
-	With(fields KV) *LoggerEntry
-	Err(err error) *LoggerEntry
+	With(fields KV) FieldLogger
+	Err(err error) FieldLogger
 
 	Fields() KV
 
@@ -72,7 +78,7 @@ func (c *LoggerEntry) NewContext(ctx context.Context) context.Context {
 }
 
 // Ctx will use any logging context contained in context.Context to append to the current log context
-func (c *LoggerEntry) Ctx(ctx context.Context) *LoggerEntry {
+func (c *LoggerEntry) Ctx(ctx context.Context) FieldLogger {
 	if fields, ok := ctx.Value(logKey).(KV); ok {
 		return c.With(fields)
 	}
@@ -85,7 +91,7 @@ func (c *LoggerEntry) AppendContext(ctx context.Context, fields KV) context.Cont
 }
 
 // With creates a new LoggerEntry and adds the fields to it
-func (c *LoggerEntry) With(fields KV) *LoggerEntry {
+func (c *LoggerEntry) With(fields KV) FieldLogger {
 	// type conversion of same type without refection
 	data := make(logrus.Fields, len(fields))
 	for k, v := range fields {
@@ -96,7 +102,7 @@ func (c *LoggerEntry) With(fields KV) *LoggerEntry {
 }
 
 // Err adds an error and returns a new LoggerEntry
-func (c *LoggerEntry) Err(err error) *LoggerEntry {
+func (c *LoggerEntry) Err(err error) FieldLogger {
 	entry := c.Entry.WithError(err)
 	return &LoggerEntry{entry}
 }
@@ -135,10 +141,10 @@ func (c *LoggerEntry) AddHook(hook logrus.Hook) {
 	c.Logger.Hooks.Add(hook)
 }
 
-// New creates a new LoggerEntry with a new Logger context (formatter, level, output, hooks)
-func New() (context *LoggerEntry) {
+// New creates a new FieldLogger with a new Logger (formatter, level, output, hooks)
+func New() (entry *LoggerEntry) {
 	base := logrus.New()
-	context = &LoggerEntry{logrus.NewEntry(base)}
+	logger := &LoggerEntry{logrus.NewEntry(base)}
 	fields := make(KV)
 	if app := os.Getenv(appName); app != "" {
 		fields["app"] = app
@@ -148,15 +154,15 @@ func New() (context *LoggerEntry) {
 	}
 	if level := os.Getenv(levelName); level != "" {
 		if l, err := logrus.ParseLevel(level); err == nil {
-			context.SetLevel(l)
+			logger.SetLevel(l)
 		} else {
-			context.Err(err).With(KV{
+			logger.Err(err).With(KV{
 				"module":   "log_initialisation",
 				"tag":      "log_new_failed",
 				"logLevel": level,
 			}).Error("The supplied log level is invalid")
 		}
 	}
-	context = context.With(fields)
+	entry, _ = logger.With(fields).(*LoggerEntry)
 	return
 }

--- a/log/context_test.go
+++ b/log/context_test.go
@@ -45,17 +45,6 @@ func TestNewContext(t *testing.T) {
 	assert.Equal(t, "test2", hook.LastEntry().Data["test"])
 }
 
-func TestNewContextKeepsOldContextValues(t *testing.T) {
-	ctx := context.WithValue(context.Background(), "foo", "bar")
-	ctx = context.WithValue(ctx, 0, "foo")
-
-	logger := New()
-	ctx = logger.With(KV{"key": "value"}).NewContext(ctx)
-
-	assert.Equal(t, "bar", ctx.Value("foo"))
-	assert.Equal(t, "foo", ctx.Value(0))
-}
-
 func TestMergeContext(t *testing.T) {
 	logger := New().With(KV{"test": 1})
 
@@ -137,4 +126,17 @@ func testAppendContext(t *testing.T) {
 
 	assert.Equal(t, KV{"key": "value", "key2": "value2"}, logger2.Ctx(ctx).Fields())
 	assert.Equal(t, KV{}, logger2.Fields())
+}
+
+func TestNewContextKeepsOldContextValues(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "foo", "bar")
+	ctx = context.WithValue(ctx, 0, "foo")
+
+	logger := New()
+	ctx = logger.With(KV{"key": "value"}).NewContext(ctx)
+
+	assert.Equal(t, "bar", ctx.Value("foo"))
+	assert.Equal(t, "foo", ctx.Value(0))
+	logger2 := New()
+	assert.Equal(t, KV{"key": "value"}, logger2.Ctx(ctx).Fields())
 }

--- a/log/context_test.go
+++ b/log/context_test.go
@@ -128,15 +128,22 @@ func testAppendContext(t *testing.T) {
 	assert.Equal(t, KV{}, logger2.Fields())
 }
 
+type newKey int
+
+const (
+	keyOne newKey = iota
+	keyTwo
+)
+
 func TestNewContextKeepsOldContextValues(t *testing.T) {
-	ctx := context.WithValue(context.Background(), "foo", "bar")
-	ctx = context.WithValue(ctx, 0, "foo")
+	ctx := context.WithValue(context.Background(), keyOne, "bar")
+	ctx = context.WithValue(ctx, keyTwo, "foo")
 
 	logger := New()
 	ctx = logger.With(KV{"key": "value"}).NewContext(ctx)
 
-	assert.Equal(t, "bar", ctx.Value("foo"))
-	assert.Equal(t, "foo", ctx.Value(0))
+	assert.Equal(t, "bar", ctx.Value(keyOne))
+	assert.Equal(t, "foo", ctx.Value(keyTwo))
 	logger2 := New()
 	assert.Equal(t, KV{"key": "value"}, logger2.Ctx(ctx).Fields())
 }

--- a/log/exported.go
+++ b/log/exported.go
@@ -99,14 +99,24 @@ func Debug(args ...interface{}) {
 	logEntry.Debug(args...)
 }
 
+// Info logs a message at level Info on the standard logger.
+func Info(args ...interface{}) {
+	logEntry.Info(args...)
+}
+
 // Print logs a message at level Info on the standard logger.
 func Print(args ...interface{}) {
 	logEntry.Print(args...)
 }
 
-// Info logs a message at level Info on the standard logger.
-func Info(args ...interface{}) {
-	logEntry.Info(args...)
+// Warn logs a message at level Warning on the standard logger.
+func Warn(args ...interface{}) {
+	logEntry.Warn(args...)
+}
+
+// Warning logs a message at level Warning on the standard logger.
+func Warning(args ...interface{}) {
+	logEntry.Warning(args...)
 }
 
 // Error logs a message at level Error on the standard logger.
@@ -114,14 +124,19 @@ func Error(args ...interface{}) {
 	logEntry.Error(args...)
 }
 
+// Fatal logs a message at level Fatal on the standard logger
+func Fatal(args ...interface{}) {
+	logEntry.Fatal(args)
+}
+
+// Panic logs a message at level Panic on the standard logger
+func Panic(args ...interface{}) {
+	logEntry.Panic(args)
+}
+
 // Debugf logs a message at level Debug on the standard logger.
 func Debugf(format string, args ...interface{}) {
 	logEntry.Debugf(format, args...)
-}
-
-// Printf logs a message at level Info on the standard logger.
-func Printf(format string, args ...interface{}) {
-	logEntry.Printf(format, args...)
 }
 
 // Infof logs a message at level Info on the standard logger.
@@ -129,7 +144,72 @@ func Infof(format string, args ...interface{}) {
 	logEntry.Infof(format, args...)
 }
 
+// Printf logs a message at level Info on the standard logger.
+func Printf(format string, args ...interface{}) {
+	logEntry.Printf(format, args...)
+}
+
+// Warnf logs a message at level Warning on the standard logger.
+func Warnf(format string, args ...interface{}) {
+	logEntry.Warnf(format, args...)
+}
+
+// Warningf logs a message at level Warning on the standard logger.
+func Warningf(format string, args ...interface{}) {
+	logEntry.Warningf(format, args...)
+}
+
 // Errorf logs a message at level Error on the standard logger.
 func Errorf(format string, args ...interface{}) {
 	logEntry.Errorf(format, args...)
+}
+
+// Fatalf logs a message at level Fatal on the standard logger
+func Fatalf(format string, args ...interface{}) {
+	logEntry.Fatal(format, args)
+}
+
+// Panicf logs a message at level Panic on the standard logger
+func Panicf(format string, args ...interface{}) {
+	logEntry.Panic(format, args)
+}
+
+// Debugln logs a message at level Debug on the standard logger.
+func Debugln(args ...interface{}) {
+	logEntry.Debugln(args...)
+}
+
+// Infoln logs a message at level Info on the standard logger.
+func Infoln(args ...interface{}) {
+	logEntry.Infoln(args...)
+}
+
+// Println logs a message at level Info on the standard logger.
+func Println(args ...interface{}) {
+	logEntry.Println(args...)
+}
+
+// Warnln logs a message at level Warning on the standard logger.
+func Warnln(args ...interface{}) {
+	logEntry.Warnln(args...)
+}
+
+// Warningln logs a message at level Warning on the standard logger.
+func Warningln(args ...interface{}) {
+	logEntry.Warningln(args...)
+}
+
+// Errorln logs a message at level Error on the standard logger.
+func Errorln(args ...interface{}) {
+	logEntry.Errorln(args...)
+}
+
+// Fatalln logs a message at level Fatal on the standard logger
+func Fatalln(args ...interface{}) {
+	logEntry.Fatalln(args)
+}
+
+// Panicln logs a message at level Panic on the standard logger
+func Panicln(args ...interface{}) {
+	logEntry.Panicln(args)
 }

--- a/log/exported.go
+++ b/log/exported.go
@@ -38,12 +38,6 @@ const (
 	DebugLevel
 )
 
-// key is a type to ensure unique key for context
-type key int
-
-// LogKey is the key used for context
-const logKey key = 0
-
 // SetOutput sets the standard logger output.
 func SetOutput(out io.Writer) {
 	logEntry.SetOutput(out)
@@ -70,13 +64,13 @@ func AddHook(hook logrus.Hook) {
 }
 
 // With returns a new LoggerEntry with the supplied fields
-func With(fields KV) *LoggerEntry {
+func With(fields KV) FieldLogger {
 	return logEntry.With(fields)
 }
 
 // Err creates a new LoggerEntry from the standard logger and adds an error
 // to it, using the value defined in ErrorKey as key.
-func Err(err error) *LoggerEntry {
+func Err(err error) FieldLogger {
 	return logEntry.Err(err)
 }
 
@@ -86,7 +80,7 @@ func Fields() KV {
 }
 
 // Ctx will use the provided context with its logs if applicable
-func Ctx(ctx context.Context) *LoggerEntry {
+func Ctx(ctx context.Context) FieldLogger {
 	return logEntry.Ctx(ctx)
 }
 

--- a/log/logging_test.go
+++ b/log/logging_test.go
@@ -136,3 +136,93 @@ func TestTheContextDoesNotContainAPointerToTheLogger(t *testing.T) {
 		"key2": "value2",
 	}, Ctx(ctx).Fields())
 }
+
+func TestLevels(t *testing.T) {
+	logger := New()
+	logger.SetLevel(logrus.DebugLevel)
+	hook := test.NewLocal(logger.Logger)
+
+	cases := map[string]struct {
+		level logrus.Level
+		fn    func()
+	}{
+		"debug": {
+			logrus.DebugLevel,
+			func() { logger.Debug("debug") },
+		},
+		"debugf": {
+			logrus.DebugLevel,
+			func() { logger.Debugf("debug") },
+		},
+		"debugln": {
+			logrus.DebugLevel,
+			func() { logger.Debugln("debug") },
+		},
+		"info": {
+			logrus.InfoLevel,
+			func() { logger.Info("info") },
+		},
+		"infof": {
+			logrus.InfoLevel,
+			func() { logger.Infof("info") },
+		},
+		"infoln": {
+			logrus.InfoLevel,
+			func() { logger.Infoln("info") },
+		},
+		"print": {
+			logrus.InfoLevel,
+			func() { logger.Print("print") },
+		},
+		"printf": {
+			logrus.InfoLevel,
+			func() { logger.Printf("print") },
+		},
+		"println": {
+			logrus.InfoLevel,
+			func() { logger.Println("print") },
+		},
+		"warn": {
+			logrus.WarnLevel,
+			func() { logger.Warn("warn") },
+		},
+		"warnf": {
+			logrus.WarnLevel,
+			func() { logger.Warnf("Warn") },
+		},
+		"warnln": {
+			logrus.WarnLevel,
+			func() { logger.Warnln("Warn") },
+		},
+		"warning": {
+			logrus.WarnLevel,
+			func() { logger.Warning("warn") },
+		},
+		"warningf": {
+			logrus.WarnLevel,
+			func() { logger.Warningf("Warn") },
+		},
+		"warningln": {
+			logrus.WarnLevel,
+			func() { logger.Warningln("Warn") },
+		},
+		"error": {
+			logrus.ErrorLevel,
+			func() { logger.Error("error") },
+		},
+		"errorf": {
+			logrus.ErrorLevel,
+			func() { logger.Errorf("error") },
+		},
+		"errorln": {
+			logrus.ErrorLevel,
+			func() { logger.Errorln("error") },
+		},
+	}
+
+	for k, tc := range cases {
+		tc.fn()
+		assert.Equal(t, tc.level, hook.LastEntry().Level, "test: %s", k)
+		hook.Reset()
+	}
+}

--- a/log/logging_test.go
+++ b/log/logging_test.go
@@ -67,7 +67,10 @@ func TestGlobalConfiguration(t *testing.T) {
 	assert.Equal(t, InfoLevel, logger.Logger.Level)
 	assert.IsType(t, (*logrus.TextFormatter)(nil), logger.Logger.Formatter)
 
-	logger2 := With(KV{})
+	logger2, ok := With(KV{}).(*LoggerEntry)
+	if !ok {
+		t.Error("unable to cast logger to *LoggerEntry")
+	}
 
 	assert.Equal(t, os.Stdout, logger2.Logger.Out)
 	assert.Equal(t, DebugLevel, logger2.Logger.Level)


### PR DESCRIPTION
Some refactoring

- Implements all methods in the StdLogger (so you can call standard log.<bla>) methods
- The FieldLogger interface method returns FieldLogger