### PR TITLE
handle leap seconds and time jumps when calculating duration

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -10,6 +10,9 @@ import:
   version: ^0.10.0
 - package: github.com/satori/go.uuid
   version: ^1.1.0
+- package: github.com/aristanetworks/goarista
+  subpackages:
+  - monotime
 testImport:
 - package: github.com/stretchr/testify
   version: ^1.1.4

--- a/handlers/request_logger.go
+++ b/handlers/request_logger.go
@@ -18,16 +18,19 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/aristanetworks/goarista/monotime"
 )
 
 // LogServeHTTP creates a LoggingResponseWriter from `w` if applicable and calls `caller` with the request status, size,
 // time and duration
 func LogServeHTTP(w http.ResponseWriter, req *http.Request, handler http.Handler, caller func(w LoggingResponseWriter, req *http.Request, url url.URL, ts time.Time, dur time.Duration, status, size int)) {
 	t := time.Now().UTC()
+	mt := monotime.Now()
 	logger := MakeLogger(w)
 	url := *req.URL
 	handler.ServeHTTP(logger, req)
-	dur := time.Now().UTC().Sub(t)
+	dur := time.Duration(monotime.Now() - mt)
 	caller(logger, req, url, t, dur, logger.Status(), logger.Size())
 }
 


### PR DESCRIPTION
uses `monotime` package which exports the runtime method: `nanotime` which uses a `MONOTONIC_CLOCK` and can be used to calculate the difference between times even during leap seconds/time jumps from ntp