### PR TITLE
merge the auth and recovery failure handlers

### DIFF
--- a/handlers/auth/README.md
+++ b/handlers/auth/README.md
@@ -44,7 +44,7 @@ Authorization: Graze hzYAVO9Sg98nsNh81M84O2kyXVy6K1xwHD8
 ```
 
 ```go
-keyAuth := auth.NewAPIKey("Graze", auth.FinderFunc(finder), onError)
+keyAuth := auth.NewAPIKey("Graze", auth.FinderFunc(finder), failure.HandlerFunc(onError))
 
 http.Handle("/", keyAuth.Next(router))
 ```
@@ -63,7 +63,7 @@ x-api-key: hzYAVO9Sg98nsNh81M84O2kyXVy6K1xwHD8
 The same Finder and methods can be used
 
 ```go
-keyAuth := auth.NewXAPIKey(auth.FinderFunc(finder), onError)
+keyAuth := auth.NewXAPIKey(auth.FinderFunc(finder), failure.HandlerFunc(onError))
 
 http.Handle("/", keyAuth.Next(router))
 ```

--- a/handlers/auth/README.md
+++ b/handlers/auth/README.md
@@ -10,8 +10,8 @@ Authentication provides a little bit of security to your service.
 
 Some common components are available during authentication:
 
-- `finder` (`Finder`) - Asks the application (you) if a supplied set of credentials are valid
-- `onError` (`FailHandler`) - When an error occurs during authentication, this is called so the application (you again) can handle it nicely
+- `finder` (`auth.Finder`) - Asks the application (you) if a supplied set of credentials are valid
+- `onError` (`failure.Handler`) - When an error occurs during authentication this is called. Then the application (you again) can handle it nicely
 
 ```go
 func finder(creds interface{}, r *http.Request) (interface{}, error) {

--- a/handlers/auth/apikey_test.go
+++ b/handlers/auth/apikey_test.go
@@ -16,6 +16,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/graze/golang-service/handlers/failure"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -97,10 +98,10 @@ func TestApiKeyAuthErrors(t *testing.T) {
 	rec := httptest.NewRecorder()
 
 	for k, tc := range cases {
-		auth := NewAPIKey(tc.provider, tc.finder, func(w http.ResponseWriter, r *http.Request, err error, status int) {
+		auth := NewAPIKey(tc.provider, tc.finder, failure.HandlerFunc(func(w http.ResponseWriter, r *http.Request, err error, status int) {
 			assert.IsType(t, tc.err, err, "test: %s", k)
 			assert.Equal(t, tc.status, status, "test: %s", k)
-		})
+		}))
 		handler := auth.Then(okHandler)
 		handler.ServeHTTP(rec, tc.request)
 	}
@@ -140,9 +141,9 @@ func TestValidAPIKeyAuth(t *testing.T) {
 	rec := httptest.NewRecorder()
 
 	for k, tc := range cases {
-		auth := NewAPIKey(tc.provider, tc.finder, func(w http.ResponseWriter, r *http.Request, err error, status int) {
+		auth := NewAPIKey(tc.provider, tc.finder, failure.HandlerFunc(func(w http.ResponseWriter, r *http.Request, err error, status int) {
 			t.Errorf("onError handler called. Err: %s, Status: %d, Test: %s", err, status, k)
-		})
+		}))
 
 		baseHandler := func(w http.ResponseWriter, req *http.Request) {
 			user := GetUser(req)

--- a/handlers/auth/doc.go
+++ b/handlers/auth/doc.go
@@ -46,7 +46,7 @@ Authorization Bearer Api Key Auth
 For a basic api key based authentication. It directly passes the apiKey as a the credentials to the Finder.Func method
 
 Usage:
-    keyAuth := auth.NewAPIKey("Graze", auth.FinderFunc(finder), onError)
+    keyAuth := auth.NewAPIKey("Graze", auth.FinderFunc(finder), failure.HandlerFunc(onError))
 
     http.Handle("/", keyAuth.Next(router))
 
@@ -56,7 +56,7 @@ Almost identical to the Authorization header, is using the X-Api-Key header to s
 It uses the same Finder and onError.
 
 Usage:
-    keyAuth := auth.NewXApiKey(auth.FinderFunc(finder), onError)
+    keyAuth := auth.NewXApiKey(auth.FinderFunc(finder), failure.HandlerFunc(onError))
 
     http.Handle("/", keyAuth.Next(router))
 

--- a/handlers/auth/user_test.go
+++ b/handlers/auth/user_test.go
@@ -15,6 +15,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/graze/golang-service/handlers/failure"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -52,9 +53,9 @@ func TestUserStorage(t *testing.T) {
 	rec := httptest.NewRecorder()
 
 	for k, tc := range cases {
-		auth := &APIKey{tc.provider, tc.finder, func(w http.ResponseWriter, r *http.Request, err error, status int) {
+		auth := &APIKey{tc.provider, tc.finder, failure.HandlerFunc(func(w http.ResponseWriter, r *http.Request, err error, status int) {
 			t.Errorf("onError handler called. Err: %s, Status: %d, Test: %s", err, status, k)
-		}}
+		})}
 
 		baseHandler := func(w http.ResponseWriter, req *http.Request) {
 			user := GetUser(req)

--- a/handlers/auth/xapikey_test.go
+++ b/handlers/auth/xapikey_test.go
@@ -16,6 +16,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/graze/golang-service/handlers/failure"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -50,10 +51,10 @@ func TestXApiKeyAuthErrors(t *testing.T) {
 	rec := httptest.NewRecorder()
 
 	for k, tc := range cases {
-		auth := NewXAPIKey(tc.finder, func(w http.ResponseWriter, r *http.Request, err error, status int) {
+		auth := NewXAPIKey(tc.finder, failure.HandlerFunc(func(w http.ResponseWriter, r *http.Request, err error, status int) {
 			assert.IsType(t, tc.err, err, "test: %s", k)
 			assert.Equal(t, tc.status, status, "test: %s", k)
-		})
+		}))
 		handler := auth.Then(okHandler)
 		handler.ServeHTTP(rec, tc.request)
 	}
@@ -90,9 +91,9 @@ func TestValidXAPIKeyAuth(t *testing.T) {
 	rec := httptest.NewRecorder()
 
 	for k, tc := range cases {
-		auth := NewXAPIKey(tc.finder, func(w http.ResponseWriter, r *http.Request, err error, status int) {
+		auth := NewXAPIKey(tc.finder, failure.HandlerFunc(func(w http.ResponseWriter, r *http.Request, err error, status int) {
 			t.Errorf("onError handler called. Err: %s, Status: %d, Test: %s", err, status, k)
-		})
+		}))
 
 		baseHandler := func(w http.ResponseWriter, req *http.Request) {
 			user := GetUser(req)

--- a/handlers/failure/failure.go
+++ b/handlers/failure/failure.go
@@ -23,6 +23,7 @@ The HandlerFunc converts a function to a Handler interface
 
     errorHandler = failure.Handler(func(w http.ResponseWriter, r *http.Request, err error, status int) {
         w.WriteHeader(status)
+        w.Headers().Set('x-error','some error')
         w.Write([]byte(err.Error()))
     })
 */
@@ -30,14 +31,12 @@ package failure
 
 import "net/http"
 
-// Handler handlers a panic panic and does something (outputs to w, logs, reports to third party, etc)
-//
-// Note that multiple Recoverers could write to w
+// Handler handlers an error state and does something (outputs to w, logs, reports to third party, etc)
 type Handler interface {
 	Handle(w http.ResponseWriter, r *http.Request, err error, status int)
 }
 
-// HandlerFunc provides a simple function to handle when a http.Handler panic occours
+// HandlerFunc provides a simple function to convert it into a failure.Handler
 type HandlerFunc func(http.ResponseWriter, *http.Request, error, int)
 
 // Handle implements the Handler interface for a HandlerFunc

--- a/handlers/failure/failure.go
+++ b/handlers/failure/failure.go
@@ -1,0 +1,46 @@
+// This file is part of graze/golang-service
+//
+// Copyright (c) 2016 Nature Delivered Ltd. <https://www.graze.com>
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+//
+// license: https://github.com/graze/golang-service/blob/master/LICENSE
+// link:    https://github.com/graze/golang-service
+
+/*
+Package failure provides a generic handler to do something when it all goes wrong during an http request
+
+Sometimes bad things happen and you need to handle them nicely
+
+This interface is used within this library in the auth and recovery packages.
+
+    type Handler interface {
+        Handle(w http.ResponseWriter, r *http.Request, err error, status int)
+    }
+
+The HandlerFunc converts a function to a Handler interface
+
+    errorHandler = failure.Handler(func(w http.ResponseWriter, r *http.Request, err error, status int) {
+        w.WriteHeader(status)
+        w.Write([]byte(err.Error()))
+    })
+*/
+package failure
+
+import "net/http"
+
+// Handler handlers a panic panic and does something (outputs to w, logs, reports to third party, etc)
+//
+// Note that multiple Recoverers could write to w
+type Handler interface {
+	Handle(w http.ResponseWriter, r *http.Request, err error, status int)
+}
+
+// HandlerFunc provides a simple function to handle when a http.Handler panic occours
+type HandlerFunc func(http.ResponseWriter, *http.Request, error, int)
+
+// Handle implements the Handler interface for a HandlerFunc
+func (f HandlerFunc) Handle(w http.ResponseWriter, r *http.Request, err error, status int) {
+	f(w, r, err, status)
+}

--- a/handlers/recovery/README.md
+++ b/handlers/recovery/README.md
@@ -14,7 +14,7 @@ You can create custom handlers to do something when a panic occurs:
 A simple handler would be to return the error text to the user in the body of the response:
 
 ```go
-echoHandler := recovery.HandlerFunc(func (w io.Writer, r *http.Request, err error, status int) {
+echoHandler := failure.HandlerFunc(func (w io.Writer, r *http.Request, err error, status int) {
     w.Write([]byte(err.Error()))
 })
 ```

--- a/handlers/recovery/doc.go
+++ b/handlers/recovery/doc.go
@@ -18,7 +18,7 @@ You can create custom handlers to do something when a panic occurs:
 
 Example Handler:
 
-    echoHandler := recovery.HandlerFunc(func (w io.Writer, r *http.Request, err error, status int) {
+    echoHandler := failure.HandlerFunc(func (w http.ResponseWriter, r *http.Request, err error, status int) {
         w.Write([]byte(err.Error()))
     })
 

--- a/handlers/recovery/logger.go
+++ b/handlers/recovery/logger.go
@@ -11,10 +11,10 @@
 package recovery
 
 import (
-	"io"
 	"net/http"
 	"runtime/debug"
 
+	"github.com/graze/golang-service/handlers/failure"
 	"github.com/graze/golang-service/log"
 )
 
@@ -24,7 +24,7 @@ type panicLogger struct {
 }
 
 // Logger takes a panic event and writes a stack trace to the log
-func (l panicLogger) Handle(w io.Writer, r *http.Request, err error, status int) {
+func (l panicLogger) Handle(w http.ResponseWriter, r *http.Request, err error, status int) {
 	l.logger.Ctx(r.Context()).With(log.KV{
 		"tag":    "critical_error",
 		"stack":  debug.Stack(),
@@ -48,6 +48,6 @@ func (l panicLogger) Handle(w io.Writer, r *http.Request, err error, status int)
 //  logPanic := recovery.PanicLogger(logger.With(log.KV{"module":"panic.handler"}))
 //  recoverer := recovery.New(logPanic)
 //  http.ListenAndServe(":80", recoverer.Handle(r))
-func PanicLogger(logger log.FieldLogger) Handler {
+func PanicLogger(logger log.FieldLogger) failure.Handler {
 	return &panicLogger{logger}
 }

--- a/handlers/recovery/middleware_test.go
+++ b/handlers/recovery/middleware_test.go
@@ -11,11 +11,11 @@
 package recovery
 
 import (
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/graze/golang-service/handlers/failure"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,7 +27,7 @@ var panicHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Reques
 	panic("oh no!")
 })
 
-var echoRecoverer = HandlerFunc(func(w io.Writer, r *http.Request, err error, status int) {
+var echoRecoverer = failure.HandlerFunc(func(w http.ResponseWriter, r *http.Request, err error, status int) {
 	w.Write([]byte(err.Error()))
 })
 
@@ -52,17 +52,17 @@ func TestHandlerCallsNextHandlerWhenNoPanicOccours(t *testing.T) {
 
 func TestPanics(t *testing.T) {
 	cases := map[string]struct {
-		handlers []Handler
+		handlers []failure.Handler
 		body     string
 		status   int
 	}{
 		"echo": {
-			[]Handler{echoRecoverer},
+			[]failure.Handler{echoRecoverer},
 			"oh no!",
 			http.StatusInternalServerError,
 		},
 		"multiple": {
-			[]Handler{echoRecoverer, echoRecoverer},
+			[]failure.Handler{echoRecoverer, echoRecoverer},
 			"oh no!oh no!",
 			http.StatusInternalServerError,
 		},

--- a/handlers/recovery/raygun.go
+++ b/handlers/recovery/raygun.go
@@ -11,10 +11,10 @@
 package recovery
 
 import (
-	"io"
 	"net/http"
 
 	"github.com/MindscapeHQ/raygun4go"
+	"github.com/graze/golang-service/handlers/failure"
 	"github.com/graze/golang-service/log"
 )
 
@@ -31,13 +31,13 @@ type raygunRecoverer struct {
 }
 
 // Recover creates a new raygun client each time as the details of each error will change per request
-func (l raygunRecoverer) Handle(w io.Writer, r *http.Request, err error, status int) {
+func (l raygunRecoverer) Handle(w http.ResponseWriter, r *http.Request, err error, status int) {
 	l.client.Request(r)
 	l.client.CustomData(log.Ctx(r.Context()).Fields())
 	l.client.CreateError(err.Error())
 }
 
 // Raygun creates a Raygun Recoverer given the details
-func Raygun(client raygunClient) Handler {
+func Raygun(client raygunClient) failure.Handler {
 	return &raygunRecoverer{client}
 }


### PR DESCRIPTION
`handlers/auth` and `handlers/recovery` had a very similar `OnError` type error handler (`func (w io.Writer, r *http.Request, err error, status int)` and `func (w http.ResponseWriter, r *http.Request, err error, status int)`)

The initial reason they were different is because failure didn't need to write the status... but it can now write headers (which might be important)

### Changes

- merge `auth.FailHandler` and `recovery.Handler` into `failure.Handler`
  - support `func (w http.ResponseWriter, r *http.Request, err error, status int)`
- ...which means recovery handers can write headers now too
- If you want to use this you will need to change auth constructor and recovery constructors.
- `auth.NewAPIKey` signature has changed
- `auth.NewXAPIKey` signature has changed
- `recovery.New` signature has changed