### PR TITLE
Remove WriteHeader from recovery so other handlers can write headers

### DIFF
--- a/handlers/recovery/README.md
+++ b/handlers/recovery/README.md
@@ -32,6 +32,17 @@ recoverer = recovery.New(echoHandler)
 http.ListenAndServe(":80", recoverer)
 ```
 
+When calling each handler, recovery will pass http.StatusInternalServerError as the status, but it
+won't write the header to allow other handlers to write their own headers. You'll need do something like:
+
+```go
+fiveHundredHandler = failure.HandlerFunc(func (w http.ResponseWriter, r *http.Request, err error, status int) {
+    w.writeHeader(status)
+}))
+```
+
+You can of course write a different status should you so choose.
+
 ## Logging Panic Handler:
 
 The logging Recoverer will log an output of the recovered panic for debugging.

--- a/handlers/recovery/doc.go
+++ b/handlers/recovery/doc.go
@@ -31,6 +31,15 @@ recovery provides an http.Handler for use with http middleware
     recoverer = recovery.New(echoHandler)
     http.ListenAndServe(":80", recoverer)
 
+When calling each handler, recovery will pass http.StatusInternalServerError as the status, but it
+won't write the header to allow other handlers to write their own headers. You'll need do something like:
+
+    fiveHundredHandler = failure.HandlerFunc(func (w http.ResponseWriter, r *http.Request, err error, status int) {
+        w.writeHeader(status)
+    }))
+
+You can of course write a different status should you so choose.
+
 Logging Panic Handler
 
 The logging Recoverer will log an output of the recovered panic for debugging.

--- a/handlers/recovery/middleware.go
+++ b/handlers/recovery/middleware.go
@@ -32,7 +32,6 @@ func (m *middleware) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 				err = errors.New(e.(string))
 			}
 
-			w.WriteHeader(http.StatusInternalServerError)
 			for _, r := range m.handlers {
 				r.Handle(w, req, err, http.StatusInternalServerError)
 			}

--- a/handlers/recovery/middleware_test.go
+++ b/handlers/recovery/middleware_test.go
@@ -28,6 +28,7 @@ var panicHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Reques
 })
 
 var echoRecoverer = failure.HandlerFunc(func(w http.ResponseWriter, r *http.Request, err error, status int) {
+	w.WriteHeader(status)
 	w.Write([]byte(err.Error()))
 })
 


### PR DESCRIPTION
I'm using recovery and trying to write a content-type header in a handler, but currently recovered calls `WriteHeader()` before calling the handlers.

Removing that call will allow handles to manipulate headers, but does mean the user needs to call `WriteHeader()` themselves.