### PR TITLE
Validate empty

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -58,7 +58,7 @@ type Validatable interface {
 // the Validatable variable will get populated with the contents of the body provided by *http.Request
 //
 // The base set of error types returned from this method are:
-// 	validate.IOError
+// 	*validate.IOError
 //  *json.SyntaxError
 //	*json.UnmarshalFieldError
 //	*json.UnmarshalTypeError
@@ -84,14 +84,19 @@ type Validatable interface {
 //		}
 //	}
 func JSONRequest(ctx context.Context, r *http.Request, v Validatable) error {
-	return Reader(ctx, r.Body, json.Unmarshal, v)
+	return Reader(ctx, r.Body, func(data []byte, v interface{}) error {
+		if len(data) == 0 {
+			data = []byte("{}")
+		}
+		return json.Unmarshal(data, v)
+	}, v)
 }
 
 // XMLRequest takes an http request docodes the xml into an item and validates the provided item
 //
 // The base set of error types returned from this method are:
-// 	validate.IOError
-//  *xml.SyntaxError
+// 	*validate.IOError
+// 	*xml.SyntaxError
 //	*xml.TagPathError
 //	*xml.UnmarshalError
 func XMLRequest(ctx context.Context, r *http.Request, v Validatable) error {
@@ -107,7 +112,7 @@ func XMLRequest(ctx context.Context, r *http.Request, v Validatable) error {
 //		Description string `json:"description"`
 //	}
 //
-//  func (i *ApiInput) Validate(ctx context.Context) error {
+// 	func (i *ApiInput) Validate(ctx context.Context) error {
 //		if utf8.RuneCountInString(i.Name) == 0 {
 //			return fmt.Errorf("the field: name must be provided and not empty")
 //		}

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -38,6 +38,12 @@ type XMLStruct struct {
 	Drinks int    `XmlName:"drinks"`
 }
 
+type emptyStruct struct{}
+
+func (s *emptyStruct) Validate(ctx context.Context) error {
+	return nil
+}
+
 func (x *XMLStruct) Validate(ctx context.Context) error {
 	return nil
 }
@@ -131,6 +137,12 @@ func TestJsonRequest(t *testing.T) {
 }
 }`),
 			&TypesStruct{},
+			false,
+			"",
+		},
+		"empty": {
+			newRequest(t, "POST", "/thing", ``),
+			&emptyStruct{},
 			false,
 			"",
 		},


### PR DESCRIPTION
- Validation: Handle when no body is provided for json requests